### PR TITLE
Bump gittuf version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ of gittuf itself.
 ## Optional Input
 
 `gittuf-version`: Used to specify the version of gittuf to install (default:
-`0.10.2`). In addition to the specific version number, `main` is also supported
+`0.11.0`). In addition to the specific version number, `main` is also supported
 to build off the [source repository](https://github.com/gittuf/gittuf)'s `main`
 branch. Note: do not prefix `v` in the version number.

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   gittuf-version:
     description: 'Version of gittuf to install'
     required: false
-    default: '0.10.2'
+    default: '0.11.0'
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
This bumps the default gittuf version to v0.11.0.