### PR TITLE
ci: Bump go version to 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: Install gittuf
         uses: ./
         with:


### PR DESCRIPTION
This PR bumps the go version in CI to 1.25.