### PR TITLE
Bump default version of gittuf to v0.14.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install gittuf
         uses: ./
         with:
-          gittuf-version: '0.14.0'
+          gittuf-version: '0.14.1'
       - name: Verify install
         run: gittuf version
   test_gittuf_installer_from_main_branch:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of gittuf itself.
 ## Optional Input
 
 `gittuf-version`: Used to specify the version of gittuf to install (default:
-`0.14.0`). In addition to the specific version number, `main` is also supported
+`0.14.1`). In addition to the specific version number, `main` is also supported
 to build off the [source repository](https://github.com/gittuf/gittuf)'s `main`
 branch. Note: do not prefix `v` in the version number.
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   gittuf-version:
     description: 'Version of gittuf to install'
     required: false
-    default: '0.14.0'
+    default: '0.14.1'
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
## Description

Bumps default version of gittuf to `v0.14.1`.

## AI Usage

- [X] I **did not** use generative AI at all in making the content of this pull
  request.

## Contributor Checklist

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [X] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
